### PR TITLE
reordered includes and added .vs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 cmake-build-*/
 
 build/
+
+.vs/

--- a/src/editor/util/util.cpp
+++ b/src/editor/util/util.cpp
@@ -2,9 +2,9 @@
 
 #include <vector>
 
+#include <windows.h>
 #include <commdlg.h>
 #include <ShlObj_core.h>
-#include <windows.h>
 
 namespace util
 {


### PR DESCRIPTION
reordered the `<windows.h>` include to fix cmake build errors and added `.vs/` to `.gitignore`.